### PR TITLE
Preparing v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.1.x] - xxxx-xx-xx
+### Added
+- Restriction for ping targets. Just to make sure not everyone can ping for Capitals or even Supers and Titans if these are configured ping targets.
+
 ### Changed
 - Set time selection steps to 15 minutes instead of 60 in te datepicker
 - Set Monday as the beginning of the week in the datepicker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.1.x] - xxxx-xx-xx
+## [1.0.0] - 2020-07-16
 ### Added
-- Restriction for ping targets. Just to make sure not everyone can ping for Capitals or even Supers and Titans if these are configured ping targets.
+- Restriction for ping targets. Just to make sure not everyone can ping for Capitals or even Supers and Titans if these are configured ping targets. (#18)
 
 ### Changed
 - Set time selection steps to 15 minutes instead of 60 in te datepicker
 - Set Monday as the beginning of the week in the datepicker
 
 ### Fixed 
-- Our Australian time travelers and everyone else who lives in the future (UTC+x) is now able to pre-ping fleets that are coming up in 2 hours Eve time, which might still be in their past local time, depending on how far in the future they live.
+- Our Australian time travelers and everyone else who lives in the future (UTC+x) is now able to pre-ping fleets that are coming up in 2 hours Eve time, which might still be in their past local time, depending on how far in the future they live. (#19)
 
 ## [0.1.10] - 2020-07-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.x] - xxxx-xx-xx
+### Changed
+- Set time selection steps to 15 minutes instead of 60 in te datepicker
+- Set Monday as the beginning of the week in the datepicker
+
+### Fixed 
+- Our Australian time travelers and everyone else who lives in the future (UTC+x) is now able to pre-ping fleets that are coming up in 2 hours Eve time, which might still be in their past local time, depending on how far in the future they live.
+
 ## [0.1.10] - 2020-07-16
 ### Added
 - Option to embed automatic pings via webhook (#13)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ AA_DISCORDFORMATTER_ADDITIONAL_PING_TARGETS = [
         'roleName': 'Member'
     },
     {
+        # restricted to "Capital FCs" (GroupID 5) and "Super Capital FCs" (GroupID 7)
+        'restrictedToGroup': [
+            5,
+            7,
+        ],
         'roleId': 'xxxxxxxxxxxxxxxxxx',
         'roleName': 'Capital Pilots'
     },

--- a/discordpingformatter/__init__.py
+++ b/discordpingformatter/__init__.py
@@ -1,4 +1,4 @@
 default_app_config = 'discordpingformatter.apps.AaDiscordPingFormatterConfig'
 
-__version__ = '0.1.10'
+__version__ = '1.0.0'
 __title__ = 'Discord Ping Formatter'

--- a/discordpingformatter/templates/discordpingformatter/form.html
+++ b/discordpingformatter/templates/discordpingformatter/form.html
@@ -9,9 +9,21 @@
                 {% if additionalPingTargets|length > 0 %}
                     <option value="" disabled></option>
                     <optgroup label="Additionally configured ping targets">
-                        {% for pingTarget in additionalPingTargets %}
-                            <option value="{{ pingTarget.roleId }}">@{{ pingTarget.roleName }}</option>
-                        {% endfor %}
+                        {% load update_variable %}
+                        {% with "false" as showPingTarget %}
+                            {% for pingTarget in additionalPingTargets %}
+                                {% update_variable "false" as showPingTarget %}
+
+                                {% for group in userGroups %}
+                                    {% if showPingTarget == "false" %}
+                                        {% if pingTarget.restrictedToGroup|length == 0 or group.id in pingTarget.restrictedToGroup %}
+                                            <option value="{{ pingTarget.roleId }}">@{{ pingTarget.roleName }}</option>
+                                            {% update_variable "true" as showPingTarget %}
+                                        {% endif %}
+                                    {% endif %}
+                                {% endfor %}
+                            {% endfor %}
+                        {% endwith %}
                     </optgroup>
                 {% endif %}
             </select>
@@ -39,15 +51,15 @@
                     <option value="" disabled></option>
                     <optgroup label="Configured ping channels">
                         {% load update_variable %}
-                        {% with "false" as showOption %}
+                        {% with "false" as showWebhook %}
                             {% for pingWebhook in additionalPingWebhooks %}
-                                {% update_variable "false" as showOption %}
+                                {% update_variable "false" as showWebhook %}
 
                                 {% for group in userGroups %}
-                                    {% if showOption == "false" %}
+                                    {% if showWebhook == "false" %}
                                         {% if pingWebhook.restrictedToGroup|length == 0 or group.id in pingWebhook.restrictedToGroup %}
                                             <option value="{{ pingWebhook.discordWebhookUrl }}">{{ pingWebhook.discordChannelName }}</option>
-                                            {% update_variable "true" as showOption %}
+                                            {% update_variable "true" as showWebhook %}
                                         {% endif %}
                                     {% endif %}
                                 {% endfor %}

--- a/discordpingformatter/templates/discordpingformatter/form.html
+++ b/discordpingformatter/templates/discordpingformatter/form.html
@@ -1,170 +1,39 @@
 <fieldset class="aa-discord-ping-formatter-form">
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="pingTarget">Ping Target</label>
-        <div class="col-md-9">
-            <select id="pingTarget" name="pingTarget" class="form-control">
-                <option value="@here">@here</option>
-                <option value="@everyone">@everyone</option>
+    <!-- pingTarget.html -->
+    {% include 'discordpingformatter/form/pingTargets.html' %}
 
-                {% if additionalPingTargets|length > 0 %}
-                    <option value="" disabled></option>
-                    <optgroup label="Additionally configured ping targets">
-                        {% load update_variable %}
-                        {% with "false" as showPingTarget %}
-                            {% for pingTarget in additionalPingTargets %}
-                                {% update_variable "false" as showPingTarget %}
+    <!-- prePing.html -->
+    {% include 'discordpingformatter/form/prePing.html' %}
 
-                                {% for group in userGroups %}
-                                    {% if showPingTarget == "false" %}
-                                        {% if pingTarget.restrictedToGroup|length == 0 or group.id in pingTarget.restrictedToGroup %}
-                                            <option value="{{ pingTarget.roleId }}">@{{ pingTarget.roleName }}</option>
-                                            {% update_variable "true" as showPingTarget %}
-                                        {% endif %}
-                                    {% endif %}
-                                {% endfor %}
-                            {% endfor %}
-                        {% endwith %}
-                    </optgroup>
-                {% endif %}
-            </select>
-        </div>
-    </div>
+    <!-- pingChannel.html -->
+    {% include 'discordpingformatter/form/pingChannel.html' %}
 
-    <div class="form-group clearfix">
-        <div class="col-md-3">&nbsp;</div>
-        <div class="col-md-9">
-            <div class="checkbox">
-                <label for="prePing">
-                    <input type="checkbox" name="prePing" id="prePing" value="1"> Pre-Ping
-                </label>
-            </div>
-        </div>
-    </div>
+    <!-- fleetType.html -->
+    {% include 'discordpingformatter/form/fleetType.html' %}
 
-    {% if additionalPingWebhooks|length > 0 %}
-        <div class="form-group clearfix">
-            <label class="col-md-3 control-label" for="pingTarget">Ping Channel<br><span class="small">Select a channel to ping it automatically</span></label>
-            <div class="col-md-9">
-                <select id="pingChannel" name="pingChannel" class="form-control">
-                    <option value="">None, just format it for me</option>
+    <!-- fleetCommander.html -->
+    {% include 'discordpingformatter/form/fleetCommander.html' %}
 
-                    <option value="" disabled></option>
-                    <optgroup label="Configured ping channels">
-                        {% load update_variable %}
-                        {% with "false" as showWebhook %}
-                            {% for pingWebhook in additionalPingWebhooks %}
-                                {% update_variable "false" as showWebhook %}
+    <!-- fleetName.html -->
+    {% include 'discordpingformatter/form/fleetName.html' %}
 
-                                {% for group in userGroups %}
-                                    {% if showWebhook == "false" %}
-                                        {% if pingWebhook.restrictedToGroup|length == 0 or group.id in pingWebhook.restrictedToGroup %}
-                                            <option value="{{ pingWebhook.discordWebhookUrl }}">{{ pingWebhook.discordChannelName }}</option>
-                                            {% update_variable "true" as showWebhook %}
-                                        {% endif %}
-                                    {% endif %}
-                                {% endfor %}
-                            {% endfor %}
-                        {% endwith %}
-                    </optgroup>
-                </select>
-            </div>
-        </div>
-    {% endif %}
+    <!-- formupLocation.html -->
+    {% include 'discordpingformatter/form/formupLocation.html' %}
 
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="fleetType">Fleet Type</label>
-        <div class="col-md-9">
-            <select id="fleetType" name="fleetType" class="form-control">
-                <option value="">Please select</option>
-                <option value="Roaming" data-embed-color="#81FD2D">Roam</option>
-                <option value="Home Defense" data-embed-color="#F1C40F">Home Defense</option>
-                <option value="StratOP" data-embed-color="#E67E22">StratOP</option>
-                <option value="CTA" data-embed-color="#E91E63">CTA</option>
+    <!-- formupTime.html -->
+    {% include 'discordpingformatter/form/formupTime.html' %}
 
-                {% if additionalFleetTypes|length > 0 %}
-                    <option value="" disabled></option>
-                    <optgroup label="Additionally configured fleet types">
-                        {% for fleetType in additionalFleetTypes %}
-                            {% if fleetType.fleetType %}
-                                <option value="{{ fleetType.fleetType }}" data-embed-color="{{ fleetType.embedColor }}">{{ fleetType.fleetType }}</option>
-                            {% else %}
-                                <option value="{{ fleetType }}" data-embed-color="#FAA61A">{{ fleetType }}</option>
-                            {% endif %}
-                        {% endfor %}
-                    </optgroup>
-                {% endif %}
-            </select>
-        </div>
-    </div>
+    <!-- fleetComms.html -->
+    {% include 'discordpingformatter/form/fleetComms.html' %}
 
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="fcName">FC Name</label>
-        <div class="col-md-9">
-            <input id="fcName" name="fcName" type="text" class="form-control input-md" value="{{ mainCharacter }}">
-        </div>
-    </div>
+    <!-- fleetDoctrine.html -->
+    {% include 'discordpingformatter/form/fleetDoctrine.html' %}
 
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="fleetName">Fleet Name</label>
-        <div class="col-md-9">
-            <input id="fleetName" name="fleetName" type="text" class="form-control input-md">
-        </div>
-    </div>
+    <!-- srp.html -->
+    {% include 'discordpingformatter/form/srp.html' %}
 
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="formupLocation">Formup Location</label>
-        <div class="col-md-9">
-            <input id="formupLocation" name="formupLocation" type="text" class="form-control input-md">
-        </div>
-    </div>
-
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="formupTime">Formup Time<br><span class="small">Always use Eve Time</span></label>
-        <div class="col-md-9">
-            <input id="formupTime" name="formupTime" type="text" class="form-control input-md" disabled>
-            <span class="small">To enable this field, either make it a Pre-Ping (checkbox above) or uncheck "Formup NOW" (checkbox below).</span>
-            {% if timezones_installed %}
-                <span class="small">Timezones module is installed. Link to time zone conversion will be added automatically if you set a date and time here.</span>
-            {% endif %}
-            <div class="checkbox">
-                <label for="formupTimeNow">
-                    <input type="checkbox" name="formupTimeNow" id="formupTimeNow" value="1" checked> Formup NOW<br><span class="small">If this checkbox is active, formup time will be set to "NOW" and the time in the field above (if any is set) will be ignored.</span>
-                </label>
-            </div>
-        </div>
-    </div>
-
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="fleetComms">Fleet Comms</label>
-        <div class="col-md-9">
-            <input id="fleetComms" name="fleetComms" type="text" class="form-control input-md">
-        </div>
-    </div>
-
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="fleetDoctrine">Ships / Doctrine</label>
-        <div class="col-md-9">
-            <input id="fleetDoctrine" name="fleetDoctrine" type="text" class="form-control input-md">
-        </div>
-    </div>
-
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="fleetSrp">SRP</label>
-        <div class="col-md-9">
-            <select id="fleetSrp" name="fleetSrp" class="form-control">
-                <option value="">Please select</option>
-                <option value="Yes">Yes</option>
-                <option value="No">No</option>
-            </select>
-        </div>
-    </div>
-
-    <div class="form-group clearfix">
-        <label class="col-md-3 control-label" for="additionalInformation">Additional Information</label>
-        <div class="col-md-9">
-            <textarea class="form-control" id="additionalInformation" name="additionalInformation" rows="7"></textarea>
-        </div>
-    </div>
+    <!-- additionalInformation.html -->
+    {% include 'discordpingformatter/form/additionalInformation.html' %}
 
     <div class="form-group clearfix">
         <label class="col-md-3 control-label" for="createPingText"></label>

--- a/discordpingformatter/templates/discordpingformatter/form/additionalInformation.html
+++ b/discordpingformatter/templates/discordpingformatter/form/additionalInformation.html
@@ -1,0 +1,6 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="additionalInformation">Additional Information</label>
+    <div class="col-md-9">
+        <textarea class="form-control" id="additionalInformation" name="additionalInformation" rows="7"></textarea>
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/fleetCommander.html
+++ b/discordpingformatter/templates/discordpingformatter/form/fleetCommander.html
@@ -1,0 +1,6 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="fcName">FC Name</label>
+    <div class="col-md-9">
+        <input id="fcName" name="fcName" type="text" class="form-control input-md" value="{{ mainCharacter }}">
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/fleetComms.html
+++ b/discordpingformatter/templates/discordpingformatter/form/fleetComms.html
@@ -1,0 +1,6 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="fleetComms">Fleet Comms</label>
+    <div class="col-md-9">
+        <input id="fleetComms" name="fleetComms" type="text" class="form-control input-md">
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/fleetDoctrine.html
+++ b/discordpingformatter/templates/discordpingformatter/form/fleetDoctrine.html
@@ -1,0 +1,6 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="fleetDoctrine">Ships / Doctrine</label>
+    <div class="col-md-9">
+        <input id="fleetDoctrine" name="fleetDoctrine" type="text" class="form-control input-md">
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/fleetName.html
+++ b/discordpingformatter/templates/discordpingformatter/form/fleetName.html
@@ -1,0 +1,6 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="fleetName">Fleet Name</label>
+    <div class="col-md-9">
+        <input id="fleetName" name="fleetName" type="text" class="form-control input-md">
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/fleetType.html
+++ b/discordpingformatter/templates/discordpingformatter/form/fleetType.html
@@ -1,0 +1,25 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="fleetType">Fleet Type</label>
+    <div class="col-md-9">
+        <select id="fleetType" name="fleetType" class="form-control">
+            <option value="">Please select</option>
+            <option value="Roaming" data-embed-color="#81FD2D">Roam</option>
+            <option value="Home Defense" data-embed-color="#F1C40F">Home Defense</option>
+            <option value="StratOP" data-embed-color="#E67E22">StratOP</option>
+            <option value="CTA" data-embed-color="#E91E63">CTA</option>
+
+            {% if additionalFleetTypes|length > 0 %}
+                <option value="" disabled></option>
+                <optgroup label="Additionally configured fleet types">
+                    {% for fleetType in additionalFleetTypes %}
+                        {% if fleetType.fleetType %}
+                            <option value="{{ fleetType.fleetType }}" data-embed-color="{{ fleetType.embedColor }}">{{ fleetType.fleetType }}</option>
+                        {% else %}
+                            <option value="{{ fleetType }}" data-embed-color="#FAA61A">{{ fleetType }}</option>
+                        {% endif %}
+                    {% endfor %}
+                </optgroup>
+            {% endif %}
+        </select>
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/formupLocation.html
+++ b/discordpingformatter/templates/discordpingformatter/form/formupLocation.html
@@ -1,0 +1,6 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="formupLocation">Formup Location</label>
+    <div class="col-md-9">
+        <input id="formupLocation" name="formupLocation" type="text" class="form-control input-md">
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/formupTime.html
+++ b/discordpingformatter/templates/discordpingformatter/form/formupTime.html
@@ -1,0 +1,15 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="formupTime">Formup Time<br><span class="small">Always use Eve Time</span></label>
+    <div class="col-md-9">
+        <input id="formupTime" name="formupTime" type="text" class="form-control input-md" disabled>
+        <span class="small">To enable this field, either make it a Pre-Ping (checkbox above) or uncheck "Formup NOW" (checkbox below).</span>
+        {% if timezones_installed %}
+            <span class="small">Timezones module is installed. Link to time zone conversion will be added automatically if you set a date and time here.</span>
+        {% endif %}
+        <div class="checkbox">
+            <label for="formupTimeNow">
+                <input type="checkbox" name="formupTimeNow" id="formupTimeNow" value="1" checked> Formup NOW<br><span class="small">If this checkbox is active, formup time will be set to "NOW" and the time in the field above (if any is set) will be ignored.</span>
+            </label>
+        </div>
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/pingChannel.html
+++ b/discordpingformatter/templates/discordpingformatter/form/pingChannel.html
@@ -1,0 +1,29 @@
+{% if additionalPingWebhooks|length > 0 %}
+    <div class="form-group clearfix">
+        <label class="col-md-3 control-label" for="pingChannel">Ping Channel<br><span class="small">Select a channel to ping it automatically</span></label>
+        <div class="col-md-9">
+            <select id="pingChannel" name="pingChannel" class="form-control">
+                <option value="">None, just format it for me</option>
+
+                <option value="" disabled></option>
+                <optgroup label="Configured ping channels">
+                    {% load update_variable %}
+                    {% with "false" as showWebhook %}
+                        {% for pingWebhook in additionalPingWebhooks %}
+                            {% update_variable "false" as showWebhook %}
+
+                            {% for group in userGroups %}
+                                {% if showWebhook == "false" %}
+                                    {% if pingWebhook.restrictedToGroup|length == 0 or group.id in pingWebhook.restrictedToGroup %}
+                                        <option value="{{ pingWebhook.discordWebhookUrl }}">{{ pingWebhook.discordChannelName }}</option>
+                                        {% update_variable "true" as showWebhook %}
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        {% endfor %}
+                    {% endwith %}
+                </optgroup>
+            </select>
+        </div>
+    </div>
+{% endif %}

--- a/discordpingformatter/templates/discordpingformatter/form/pingTargets.html
+++ b/discordpingformatter/templates/discordpingformatter/form/pingTargets.html
@@ -1,0 +1,30 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="pingTarget">Ping Target</label>
+    <div class="col-md-9">
+        <select id="pingTarget" name="pingTarget" class="form-control">
+            <option value="@here">@here</option>
+            <option value="@everyone">@everyone</option>
+
+            {% if additionalPingTargets|length > 0 %}
+                <option value="" disabled></option>
+                <optgroup label="Additionally configured ping targets">
+                    {% load update_variable %}
+                    {% with "false" as showPingTarget %}
+                        {% for pingTarget in additionalPingTargets %}
+                            {% update_variable "false" as showPingTarget %}
+
+                            {% for group in userGroups %}
+                                {% if showPingTarget == "false" %}
+                                    {% if pingTarget.restrictedToGroup|length == 0 or group.id in pingTarget.restrictedToGroup %}
+                                        <option value="{{ pingTarget.roleId }}">@{{ pingTarget.roleName }}</option>
+                                        {% update_variable "true" as showPingTarget %}
+                                    {% endif %}
+                                {% endif %}
+                            {% endfor %}
+                        {% endfor %}
+                    {% endwith %}
+                </optgroup>
+            {% endif %}
+        </select>
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/prePing.html
+++ b/discordpingformatter/templates/discordpingformatter/form/prePing.html
@@ -1,0 +1,10 @@
+<div class="form-group clearfix">
+    <div class="col-md-3">&nbsp;</div>
+    <div class="col-md-9">
+        <div class="checkbox">
+            <label for="prePing">
+                <input type="checkbox" name="prePing" id="prePing" value="1"> Pre-Ping
+            </label>
+        </div>
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/form/srp.html
+++ b/discordpingformatter/templates/discordpingformatter/form/srp.html
@@ -1,0 +1,10 @@
+<div class="form-group clearfix">
+    <label class="col-md-3 control-label" for="fleetSrp">SRP</label>
+    <div class="col-md-9">
+        <select id="fleetSrp" name="fleetSrp" class="form-control">
+            <option value="">Please select</option>
+            <option value="Yes">Yes</option>
+            <option value="No">No</option>
+        </select>
+    </div>
+</div>

--- a/discordpingformatter/templates/discordpingformatter/index.html
+++ b/discordpingformatter/templates/discordpingformatter/index.html
@@ -4,15 +4,15 @@
 {% load static %}
 
 {% block details %}
-<div class="aa-discord-ping-formatter row">
-    <div class="col-md-6">
-        {% include "discordpingformatter/form.html" %}
-    </div>
+    <div class="aa-discord-ping-formatter row">
+        <div class="col-md-6">
+            {% include "discordpingformatter/form.html" %}
+        </div>
 
-    <div class="col-md-6">
-        {% include 'discordpingformatter/ping.html' %}
+        <div class="col-md-6">
+            {% include 'discordpingformatter/ping.html' %}
+        </div>
     </div>
-</div>
 {% endblock %}
 
 {% block extra_javascript %}
@@ -30,6 +30,7 @@
     $('#formupTime').datetimepicker({
         lang: '{{ LANGUAGE_CODE }}',
         maskInput: true,
-        format: 'Y-m-d H:i'
+        format: 'Y-m-d H:i',
+        dayOfWeekStart: 1
     });
 {% endblock extra_script %}

--- a/discordpingformatter/templates/discordpingformatter/index.html
+++ b/discordpingformatter/templates/discordpingformatter/index.html
@@ -30,7 +30,6 @@
     $('#formupTime').datetimepicker({
         lang: '{{ LANGUAGE_CODE }}',
         maskInput: true,
-        format: 'Y-m-d H:i',
-        minDate: 0
+        format: 'Y-m-d H:i'
     });
 {% endblock extra_script %}

--- a/discordpingformatter/templates/discordpingformatter/index.html
+++ b/discordpingformatter/templates/discordpingformatter/index.html
@@ -31,6 +31,7 @@
         lang: '{{ LANGUAGE_CODE }}',
         maskInput: true,
         format: 'Y-m-d H:i',
-        dayOfWeekStart: 1
+        dayOfWeekStart: 1,
+        step: 15
     });
 {% endblock extra_script %}


### PR DESCRIPTION
### Added
- Restriction for ping targets. Just to make sure not everyone can ping for Capitals or even Supers and Titans if these are configured ping targets.

### Changed
- Set time selection steps to 15 minutes instead of 60 in te datepicker
- Set Monday as the beginning of the week in the datepicker

### Fixed 
- Our Australian time travelers and everyone else who lives in the future (UTC+x) is now able to pre-ping fleets that are coming up in 2 hours Eve time, which might still be in their past local time, depending on how far in the future they live.

### Closes
- Closing #18 
- Closing #19 