### PR TITLE
Minimum needed AA version raised to 2.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0a4] - 2020-09-13
+### Changed
+- Minimum AA version set to 2.7.4 since we use a feature that was introduced in this version. So make sure to update your Alliance Auth before testing this app.
+
 ## [2.0.0a3] - 2020-09-13
 ### Fixed
-- using Python 3 style `super()` without arguments
-- import order
+- Using Python 3 style `super()` without arguments
+- Import order
 
 ### Removed
 - template tags since they are no longer needed

--- a/discordpingformatter/__init__.py
+++ b/discordpingformatter/__init__.py
@@ -6,5 +6,5 @@ a couple of variable to use throughout the app
 
 default_app_config = "discordpingformatter.apps.AaDiscordPingFormatterConfig"
 
-__version__ = "2.0.0a3"
+__version__ = "2.0.0a4"
 __title__ = "Fleet Ping Formatter"

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,5 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],
     python_requires="~=3.6",
-    install_requires=["allianceauth>=2.7.2"],
+    install_requires=["allianceauth>=2.7.4"],
 )


### PR DESCRIPTION
We are using a feature that was introduced in 2.7.4, so we need to make sure we pull at least that version in.